### PR TITLE
Prevent Additional Error Count Increment in `UNIT_TEST_END`

### DIFF
--- a/svut/svut_h.sv
+++ b/svut/svut_h.sv
@@ -74,6 +74,13 @@
     svut_critical += 1;\
     end
 
+/// This macro will not increment the error counter while displaying a failure
+/// message.
+`define FAILURE(msg) \
+    begin\
+    $display("\033[1;31mFAILURE: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__);\
+    end
+
 `define ERROR(msg)\
     begin\
     $display("\033[1;31mERROR: %s (@ %0t) (%s:%0d)\033[0m", msg, $realtime, `__FILE__, `__LINE__);\
@@ -187,11 +194,11 @@ endfunction
         teardown(); \
         if (svut_error == 0) begin \
             svut_nb_test_success = svut_nb_test_success + 1; \
-            svut_msg = {"Test ", testnum, " pass"}; \
+            svut_msg = {"<< ", "Test ", testnum, ": ", svut_test_name, " >>", " pass"}; \
             `SUCCESS(svut_msg); \
         end else begin \
-            svut_msg = {"Test ", testnum, " fail"}; \
-            `ERROR(svut_msg); \
+            svut_msg = {"<< ", "Test ", testnum, ": ", svut_test_name, " >>", " fail"}; \
+            `FAILURE(svut_msg); \
             svut_fail_list = {svut_fail_list, " '", svut_test_name, "'"}; \
             svut_error_total += svut_error; \
         end \

--- a/svut/template.sv
+++ b/svut/template.sv
@@ -44,6 +44,7 @@ ${module_inst}
     //    - `SUCCESS("message"):   Print a green message if SUCCESS: prefix
     //    - `WARNING("message"):   Print an orange message with WARNING: prefix and increment warning counter
     //    - `CRITICAL("message"):  Print a purple message with CRITICAL: prefix and increment critical counter
+    //    - `FAILURE("message"):   Print a red message with FAILURE: prefix and do **not** increment error counter
     //    - `ERROR("message"):     Print a red message with ERROR: prefix and increment error counter
     //
     //    - `FAIL_IF(aSignal):                 Increment error counter if evaluaton is true

--- a/test/testsuite_run.sh
+++ b/test/testsuite_run.sh
@@ -20,7 +20,7 @@ test_run_ko_testsuite() { #@test
 test_run_ko_testsuite_error_count() { #@test
 
     run exe_ko_to_log
-    error_num=10
+    error_num=8
     [ $(grep -c "ERROR:" log) -eq "$error_num" ]
 }
 


### PR DESCRIPTION
# Description

This PR aims to prevent the `UNIT_TEST_END` macro from calling `ERROR`, which caused an unintended increment of the error count when a unit test failed.

Additionally, this PR updates the message format displayed at the end of the unit test to match the format used at the start of the test for consistency.

# Problem

The current `UNIT_TEST_END` macro calls `ERROR` macro to display an error message when a unit test fails. However, 
 the `ERROR` macro increments the `svut_error` counter. As a result, if a unit test has `n` assertion errors, it will display `n+1` errors.

For example, if the `ASSERT` statement at `example/ffd_testbench.sv:99` is made false, it will display
```bash
Error number:  2
```
instead of one due to the additional error increment caused by this issue.

![image](https://github.com/user-attachments/assets/c3407bfd-6ba8-4331-8506-6a35d8a6b99d)

# Change

1. Introduced the `FAILURE` macro, which prints a red message with a `FAILURE:` prefix and does **not** increment the error counter.
2. Updated the test reporting logic to use the `FAILURE` macro instead of `ERROR`.
3. Adjusted the message format displayed in `UNIT_TEST_END` to match the format used in `UNIT_TEST()`.
4. Updated test script for `svut` to match the updated error counter checks.

# Result

The following picture shows the result after applying the changes. It displays the error count correctly, avoiding the extra increment.
![image](https://github.com/user-attachments/assets/34d3a4e6-a562-4f10-93d8-d9e1f2dd45bb)

# Discussion

1. I think `svut_error` count should only count the number of false assertions, but I'm not sure if this aligns with the original design intention.
2. I'm uncertain if the introduction of the new message displaying macro `FAILURE` is the best approach. I decided to implement this to match the calling of the `SUCCESS()` macro when a unit test pass.

Please feel free to provide any feedback or alternative suggestions regarding this PR without any hesitation.

Best Regards